### PR TITLE
Handle NFT staking events in Atlas Mine

### DIFF
--- a/subgraphs/atlas-mine/schema.graphql
+++ b/subgraphs/atlas-mine/schema.graphql
@@ -93,6 +93,23 @@ type Reward @entity {
   user: User!
 }
 
+"NFTs staked as boosts"
+type StakedToken @entity {
+  id: Bytes!
+
+  "Staking user"
+  user: User!
+
+  "NFT contract address"
+  contract: Bytes!
+
+  "NFT token ID"
+  tokenId: BigInt!
+
+  "Quantity staked"
+  amount: Int!
+}
+
 "Amount unlocked this day and lock"
 type Unlock @entity {
   id: Bytes!
@@ -116,6 +133,9 @@ type User @entity(immutable: true) {
 
   "Rewards for this user"
   rewards: [Reward!]! @derivedFrom(field: "user")
+
+  "Staked tokens for this user"
+  stakedTokens: [StakedToken!]! @derivedFrom(field: "user")
 
   "Unlocks for this user"
   unlocks: [UserUnlock!]! @derivedFrom(field: "user")

--- a/subgraphs/atlas-mine/schema.graphql
+++ b/subgraphs/atlas-mine/schema.graphql
@@ -110,7 +110,7 @@ type StakedToken @entity {
   contract: Bytes!
 
   "NFT token ID"
-  tokenId: BigInt!
+  tokenId: Int!
 
   "Quantity staked"
   amount: Int!

--- a/subgraphs/atlas-mine/schema.graphql
+++ b/subgraphs/atlas-mine/schema.graphql
@@ -54,6 +54,9 @@ type Daily @entity {
 type Deposit @entity(immutable: true) {
   id: Bytes!
 
+  "Sortable deposit ID"
+  depositId: String!
+
   "Amount of deposit"
   amount: BigDecimal!
 
@@ -96,6 +99,9 @@ type Reward @entity {
 "NFTs staked as boosts"
 type StakedToken @entity {
   id: Bytes!
+
+  "Sortable staked token ID"
+  stakedTokenId: String!
 
   "Staking user"
   user: User!

--- a/subgraphs/atlas-mine/src/lib/helpers.ts
+++ b/subgraphs/atlas-mine/src/lib/helpers.ts
@@ -103,8 +103,10 @@ export function ensureDaily(blockstamp: BigInt): Daily {
 }
 
 export function ensureDeposit(params: Deposit__Params): Deposit {
-  const deposit = new Deposit(getId(params.user, params.index));
+  const id = getId(params.user, params.index);
+  const deposit = new Deposit(id);
 
+  deposit.depositId = id.toHexString();
   deposit.amount = params.amount.divDecimal(ONE);
   deposit.lock = getLock(params.lock).name;
   deposit.reward = deposit.id;
@@ -141,6 +143,7 @@ export function ensureStakedToken(
 
   if (!stakedToken) {
     stakedToken = new StakedToken(id);
+    stakedToken.stakedTokenId = id.toHexString();
     stakedToken.user = ensureUser(user).id;
     stakedToken.contract = contract;
     stakedToken.tokenId = tokenId;

--- a/subgraphs/atlas-mine/src/lib/helpers.ts
+++ b/subgraphs/atlas-mine/src/lib/helpers.ts
@@ -135,9 +135,9 @@ export function ensureReward(params: Harvest__Params): Reward {
 export function ensureStakedToken(
   user: Address,
   contract: Address,
-  tokenId: BigInt
+  tokenId: i32
 ): StakedToken {
-  const id = user.concat(contract).concat(Bytes.fromI32(tokenId.toI32()));
+  const id = user.concat(contract).concat(Bytes.fromI32(tokenId));
 
   let stakedToken = StakedToken.load(id);
 

--- a/subgraphs/atlas-mine/src/mapping.ts
+++ b/subgraphs/atlas-mine/src/mapping.ts
@@ -1,16 +1,24 @@
-import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
+import { BigDecimal, BigInt, store } from "@graphprotocol/graph-ts";
 
-import { Deposit, Harvest, Withdraw } from "../generated/Atlas Mine/AtlasMine";
+import {
+  Deposit,
+  Harvest,
+  Staked,
+  Unstaked,
+  Withdraw,
+} from "../generated/Atlas Mine/AtlasMine";
 import { DAY, ONE } from "./lib/constants";
 import {
   ensureDaily,
   ensureDeposit,
   ensureReward,
+  ensureStakedToken,
   ensureUnlock,
   ensureUser,
   ensureUserUnlock,
   ensureWithdrawal,
   getLock,
+  getUserOrMultisigAddress,
 } from "./lib/helpers";
 
 export function onDeposit(event: Deposit): void {
@@ -105,4 +113,35 @@ export function onWithdraw(event: Withdraw): void {
   daily.withdrawalCounts += 1;
   daily.withdrawn = daily.withdrawn.plus(amount);
   daily.save();
+}
+
+export function onStaked(event: Staked): void {
+  const params = event.params;
+  const userAddress = getUserOrMultisigAddress(event);
+
+  const stakedToken = ensureStakedToken(
+    userAddress,
+    params.nft,
+    params.tokenId
+  );
+  stakedToken.amount += params.amount.toI32();
+  stakedToken.save();
+}
+
+export function onUnstaked(event: Unstaked): void {
+  const params = event.params;
+  const userAddress = getUserOrMultisigAddress(event);
+
+  const stakedToken = ensureStakedToken(
+    userAddress,
+    params.nft,
+    params.tokenId
+  );
+  stakedToken.amount -= params.amount.toI32();
+
+  if (stakedToken.amount > 0) {
+    stakedToken.save();
+  } else {
+    store.remove("StakedToken", stakedToken.id.toHexString());
+  }
 }

--- a/subgraphs/atlas-mine/src/mapping.ts
+++ b/subgraphs/atlas-mine/src/mapping.ts
@@ -122,7 +122,7 @@ export function onStaked(event: Staked): void {
   const stakedToken = ensureStakedToken(
     userAddress,
     params.nft,
-    params.tokenId
+    params.tokenId.toI32()
   );
   stakedToken.amount += params.amount.toI32();
   stakedToken.save();
@@ -135,7 +135,7 @@ export function onUnstaked(event: Unstaked): void {
   const stakedToken = ensureStakedToken(
     userAddress,
     params.nft,
-    params.tokenId
+    params.tokenId.toI32()
   );
   stakedToken.amount -= params.amount.toI32();
 

--- a/subgraphs/atlas-mine/template.yaml
+++ b/subgraphs/atlas-mine/template.yaml
@@ -24,4 +24,8 @@ dataSources:
           handler: onHarvest
         - event: Withdraw(indexed address,indexed uint256,uint256)
           handler: onWithdraw
+        - event: Staked(address,uint256,uint256,uint256)
+          handler: onStaked
+        - event: Unstaked(address,uint256,uint256,uint256)
+          handler: onUnstaked
       file: ./src/mapping.ts


### PR DESCRIPTION
- Adds new `StakedToken` entity for tracking NFTs staked to the Atlas Mine
- Handles `Staked` and `Unstaked` events to track user NFT deposits